### PR TITLE
Add Mastodon Verification

### DIFF
--- a/content/en/welcome/_index.md
+++ b/content/en/welcome/_index.md
@@ -72,5 +72,6 @@ There are many ways you can stay involved with the Kubernetes Contributor commun
 
 {{% /blocks/section %}}
 
-
+# Mastodon Account Verification Code
+<a rel="me" href="https://hachyderm.io/@K8sContributors"></a>
 


### PR DESCRIPTION
Contributor Comms has created a K8sContributors Mastodon account on Hachyderm.io. We would like to prevent copycats and make this the "one true" K8sContributors account on Mastodon and adding this link is the verification process for Mastodon.